### PR TITLE
Add reward-based experts: RolloutExpert, OptimalDPExpert, finish MCTSExpert

### DIFF
--- a/grobnerRl/experts.py
+++ b/grobnerRl/experts.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from copy import copy
-from typing import Sequence
+from dataclasses import dataclass, field
+from math import log, sqrt
+from typing import Hashable, Sequence
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -117,6 +119,40 @@ def next_step(
     (basis, pairs), _, _, _, _ = new_env.step(pair)
 
     return basis, pairs, new_env
+
+
+def _step_with_reward(
+    env: BaseEnv, pair: int | tuple[int, int]
+) -> tuple[list[PolyElement], list[tuple[int, int]], BaseEnv, float, bool]:
+    """Like `next_step`, but also returns the env reward and a done flag."""
+    new_env = copy(env)
+    new_env.generators = list(env.generators)
+    new_env.pairs = list(env.pairs)
+    (basis, pairs), reward, terminated, truncated, _ = new_env.step(pair)
+    return basis, pairs, new_env, float(reward), bool(terminated or truncated)
+
+
+def _simulate_to_termination(
+    env: BaseEnv, policy: "Expert", gamma: float
+) -> float:
+    """Roll out `policy` to termination from `env`; return γ-discounted return.
+
+    `policy` must read its action from the observation only, not `self.env`
+    (i.e. it must be a stateless-w.r.t.-env expert such as `BasicExpert`).
+    Basis-based experts (`ClosestLMExpert`, `LeastRemainingPairsExpert`) are
+    not valid rollout policies because they read `self.env` during `__call__`.
+    """
+    basis: list[PolyElement] = env.generators
+    pairs: list[tuple[int, int]] = env.pairs
+    total: float = 0.0
+    discount: float = 1.0
+    done: bool = not pairs
+    while not done:
+        action = policy((basis, pairs))
+        basis, pairs, env, r, done = _step_with_reward(env, action)
+        total += discount * r
+        discount *= gamma
+    return total
 
 
 def get_basis(G: list[PolyElement]) -> list[PolyElement]:
@@ -344,23 +380,244 @@ class ClosestLMExpert(BasisBasedExpert):
         return best_pair
 
 
-class MCTSExpert(Expert):
+class RolloutExpert(Expert):
+    """
+    Pick the pair maximising mean γ-discounted env return when followed by
+    rollouts of a base policy to termination.
+
+    `n_rollouts > 1` is only useful for stochastic base policies (e.g.
+    `BasicExpert("random")`); for deterministic bases a single rollout
+    suffices.
+    """
+
+    base_policy: "Expert"
+    n_rollouts: int
+    gamma: float
+
     def __init__(
-        self, env: BaseEnv, rollout_policy: Expert, n_simulations=50, c=1.0, gamma=0.99
+        self,
+        env: BaseEnv,
+        base_policy: "Expert",
+        n_rollouts: int = 1,
+        gamma: float = 1.0,
     ):
-        self.env = env
-        self.rollout_policy = rollout_policy
-        self.n_simulations = n_simulations
-        self.c = c
+        super().__init__(env)
+        self.base_policy = base_policy
+        self.n_rollouts = n_rollouts
         self.gamma = gamma
 
     def __call__(
         self, observation: tuple[list[PolyElement], list[tuple[int, int]]]
     ) -> int | tuple[int, int]:
-        """
-        Select the pair that would yield the polynomial with leading monomial closest to any leading monomial in the basis.
+        _, P = observation
+        if not P:
+            raise ValueError("pair set must be nonempty")
+        return max(P, key=self._mean_return)
 
-        Arguments:
-        - observation: A tuple (G, P) where G is the current list of generators and P is the current list of pairs.
-        """
-        raise NotImplementedError()
+    def _mean_return(self, pair: tuple[int, int]) -> float:
+        total: float = 0.0
+        for _ in range(self.n_rollouts):
+            _, _, new_env, r, done = _step_with_reward(self.env, pair)
+            future: float = (
+                0.0
+                if done
+                else _simulate_to_termination(new_env, self.base_policy, self.gamma)
+            )
+            total += r + self.gamma * future
+        return total / self.n_rollouts
+
+
+class OptimalDPExpert(Expert):
+    """
+    Pick the action on the γ-optimal trajectory via memoised DFS over the
+    reachable env states. Only feasible for small ideals; raises
+    `RuntimeError` if the state-expansion budget is exceeded.
+    """
+
+    gamma: float
+    max_states: int
+    _value_cache: dict[Hashable, float]
+    _action_cache: dict[Hashable, tuple[int, int]]
+
+    def __init__(
+        self,
+        env: BaseEnv,
+        gamma: float = 1.0,
+        max_states: int = 100_000,
+    ):
+        super().__init__(env)
+        self.gamma = gamma
+        self.max_states = max_states
+        self._value_cache = {}
+        self._action_cache = {}
+
+    @staticmethod
+    def _state_key(
+        basis: list[PolyElement], pairs: list[tuple[int, int]]
+    ) -> Hashable:
+        # PolyElement has no __hash__; .terms() yields hashable (monom, coeff) tuples.
+        poly_keys: tuple = tuple(tuple(p.terms()) for p in basis)
+        return (poly_keys, tuple(sorted(pairs)))
+
+    def _value(self, env: BaseEnv) -> float:
+        key = self._state_key(env.generators, env.pairs)
+        if key in self._value_cache:
+            return self._value_cache[key]
+        if len(self._value_cache) >= self.max_states:
+            raise RuntimeError(
+                f"OptimalDPExpert: exceeded max_states={self.max_states}"
+            )
+        if not env.pairs:
+            self._value_cache[key] = 0.0
+            return 0.0
+
+        best_v: float = -float("inf")
+        best_a: tuple[int, int] | None = None
+        for pair in env.pairs:
+            _, _, new_env, r, done = _step_with_reward(env, pair)
+            future: float = 0.0 if done else self._value(new_env)
+            v: float = r + self.gamma * future
+            if v > best_v:
+                best_v, best_a = v, pair
+
+        assert best_a is not None
+        self._value_cache[key] = best_v
+        self._action_cache[key] = best_a
+        return best_v
+
+    def __call__(
+        self, observation: tuple[list[PolyElement], list[tuple[int, int]]]
+    ) -> int | tuple[int, int]:
+        if not self.env.pairs:
+            raise ValueError("pair set must be nonempty")
+        self._value(self.env)
+        return self._action_cache[
+            self._state_key(self.env.generators, self.env.pairs)
+        ]
+
+    def update_env(self, new_env: BaseEnv):
+        super().update_env(new_env)
+        self._value_cache.clear()
+        self._action_cache.clear()
+
+
+@dataclass
+class _MCTSNode:
+    """A single node in the UCT tree used by `MCTSExpert`."""
+
+    env: BaseEnv
+    pairs: list[tuple[int, int]]
+    terminal: bool
+    visit_count: int = 0
+    children: dict[tuple[int, int], "_MCTSNode"] = field(default_factory=dict)
+    child_visits: dict[tuple[int, int], int] = field(default_factory=dict)
+    child_value: dict[tuple[int, int], float] = field(default_factory=dict)
+    child_value_sq: dict[tuple[int, int], float] = field(default_factory=dict)
+    child_reward: dict[tuple[int, int], float] = field(default_factory=dict)
+
+    def untried(self) -> list[tuple[int, int]]:
+        return [p for p in self.pairs if p not in self.children]
+
+
+class MCTSExpert(Expert):
+    """
+    Classical UCT search with rollouts to estimate action values via the env
+    reward. Root action is selected by `Q(a) - var_penalty * Var(a)`, where
+    `Var` is the biased (population) variance of returns at `a`.
+    """
+
+    rollout_policy: "Expert"
+    n_simulations: int
+    c: float
+    gamma: float
+    var_penalty: float
+
+    def __init__(
+        self,
+        env: BaseEnv,
+        rollout_policy: "Expert",
+        n_simulations: int = 50,
+        c: float = 1.0,
+        gamma: float = 0.99,
+        var_penalty: float = 0.0,
+    ):
+        super().__init__(env)
+        self.rollout_policy = rollout_policy
+        self.n_simulations = n_simulations
+        self.c = c
+        self.gamma = gamma
+        self.var_penalty = var_penalty
+
+    def __call__(
+        self, observation: tuple[list[PolyElement], list[tuple[int, int]]]
+    ) -> int | tuple[int, int]:
+        _, P = observation
+        if not P:
+            raise ValueError("pair set must be nonempty")
+
+        root = self._make_node(self.env)
+        for _ in range(self.n_simulations):
+            self._simulate(root)
+
+        return max(root.children.keys(), key=lambda a: self._root_score(root, a))
+
+    def _make_node(self, env: BaseEnv) -> _MCTSNode:
+        pairs: list[tuple[int, int]] = list(env.pairs)
+        return _MCTSNode(env=env, pairs=pairs, terminal=not pairs)
+
+    def _ucb(self, node: _MCTSNode, action: tuple[int, int]) -> float:
+        q: float = node.child_value[action] / node.child_visits[action]
+        explore: float = self.c * sqrt(log(node.visit_count) / node.child_visits[action])
+        return q + explore
+
+    def _root_score(self, root: _MCTSNode, action: tuple[int, int]) -> float:
+        n: int = root.child_visits[action]
+        q: float = root.child_value[action] / n
+        # Biased (population) variance: S/N - (W/N)^2; naturally 0 when n == 1.
+        var: float = max(0.0, root.child_value_sq[action] / n - q * q)
+        return q - self.var_penalty * var
+
+    def _simulate(self, root: _MCTSNode) -> None:
+        path: list[tuple[_MCTSNode, tuple[int, int]]] = []
+        node: _MCTSNode = root
+
+        # Selection + expansion.
+        while True:
+            if node.terminal:
+                rollout_value: float = 0.0
+                break
+
+            untried: list[tuple[int, int]] = node.untried()
+            if untried:
+                action = untried[0]
+                _, _, new_env, r, done = _step_with_reward(node.env, action)
+                child = self._make_node(new_env)
+                if done:
+                    child.terminal = True
+                node.children[action] = child
+                node.child_reward[action] = r
+                node.child_visits[action] = 0
+                node.child_value[action] = 0.0
+                node.child_value_sq[action] = 0.0
+                path.append((node, action))
+                rollout_value = (
+                    0.0
+                    if child.terminal
+                    else _simulate_to_termination(
+                        child.env, self.rollout_policy, self.gamma
+                    )
+                )
+                break
+
+            action = max(node.pairs, key=lambda a: self._ucb(node, a))
+            path.append((node, action))
+            node = node.children[action]
+
+        # Backup.
+        cumulative: float = rollout_value
+        for parent, action in reversed(path):
+            cumulative = parent.child_reward[action] + self.gamma * cumulative
+            parent.child_visits[action] += 1
+            parent.child_value[action] += cumulative
+            parent.child_value_sq[action] += cumulative * cumulative
+            parent.visit_count += 1


### PR DESCRIPTION
## Summary

Adds three new experts to [grobnerRl/experts.py](grobnerRl/experts.py) whose action choices are aligned with the cumulative env reward (`-(1 + reduction_steps)` in `additions` mode or `-1` in `reductions` mode). All decide via `env.step` directly, so they automatically respect whichever `rewards` mode the `BuchbergerEnv` is configured with.

- **`RolloutExpert`** — for each candidate pair, take it then roll out a base policy to termination; pick the pair with the highest mean γ-discounted return. `n_rollouts > 1` is only useful for stochastic bases (e.g. `BasicExpert("random")`).
- **`OptimalDPExpert`** — memoised DFS over reachable env states; returns the action on the γ-optimal trajectory. Caches keyed on `(tuple(p.terms()), sorted(pairs))` because `PolyElement` is unhashable. Raises `RuntimeError` if the `max_states` budget is exceeded; `update_env` clears caches between episodes.
- **`MCTSExpert`** — replaces the `NotImplementedError` stub with classical UCT + rollouts. Selection inside the tree uses standard UCB; the root action is chosen by `Q − var_penalty · Var(a)`, where `Var` is the biased (population) variance of returns at `a` tracked via `child_value_sq`. `var_penalty = 0.0` recovers plain max-Q.

Two private helpers added next to `next_step` and reused by all three experts:
- `_step_with_reward` — like `next_step` but also returns the env `reward` and a `done` flag.
- `_simulate_to_termination` — γ-discounted rollout of a stateless policy (e.g. `BasicExpert`) to termination.

## Motivation

The pre-existing experts (`BasicExpert`, `LowestLMExpert`, `LeastRemainingPairsExpert`, `ClosestLMExpert`) all use 1-step heuristics — LM order, surviving-pair count, basis proximity — and none consult the env reward. The supervised pipeline in [grobnerRl/training/supervised.py](grobnerRl/training/supervised.py) trains both a policy head (cross-entropy on expert action) and a value head (Huber loss on cumulative `values`). Experts whose decisions are aligned with the true episode-level cost give stronger supervision for both heads. Drop-in replacement for `BasicExpert` at the call sites in [scripts/supervised.py:61](scripts/supervised.py) and [grobnerRl/data.py:272](grobnerRl/data.py).

## Verification

All four checks from the plan ran clean on the cyclic-4-like ideal `[a+b+c+d, ab+bc+cd+da, abc+bcd+cda+dab, abcd-1]` over `QQ[a,b,c,d]` with `grevlex`:

- **Smoke**: each expert returns a legal pair from `env.pairs` without raising.
- **Reward-mode alignment** (`rewards="additions"`): `BasicExpert("normal")` → −33, `RolloutExpert` → −31, `MCTSExpert(n_sim=30)` → −31. Under `rewards="reductions"` all three tie at −10 (step count drives the signal). Confirms experts read the actual env reward, not a heuristic.
- **MCTS scaling**: action converges from `(0,3)` at `n_simulations=10` to `(0,1)` at `n_simulations=50` and stays stable at 200.
- **Data-loop integration**: a loop mirroring `generate_expert_data` in [grobnerRl/data.py:272](grobnerRl/data.py) collects 5 samples per expert without error (including `update_env` calls after `env.reset`).

## Test plan

- [ ] CI passes
- [ ] Spot-check: import all three new experts and run them on one episode of `BuchbergerEnv` with both `rewards="additions"` and `rewards="reductions"`.
- [ ] Optional: swap `BasicExpert` for `RolloutExpert(env, BasicExpert(env, "normal"))` in `scripts/supervised.py` and run a 1–2 epoch training; confirm `val_loss` / `val_acc` are finite.

## Out of scope

- No changes to `models.py`, `env.py`, or `training/supervised.py`.
- No new test file (the repo has no `tests/test_experts.py` and tests were not requested).
- `MCTSExpert` is classical UCT, separate from the Gumbel AlphaZero machinery in `grobnerRl/training/gumbelMuZero.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)