### PR TITLE
Fix expected_token helper to match tokenize() output

### DIFF
--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -40,9 +40,7 @@ class DummyIdealGenerator(IdealGenerator):
 
 
 def expected_token(poly):
-    coeffs = np.array(list(map(int, poly.coeffs())), dtype=int).reshape((-1, 1))
-    monoms = np.array(poly.monoms(), dtype=int)
-    return np.concatenate((coeffs, monoms), axis=1)
+    return np.array(poly.monoms(), dtype=int)
 
 
 def test_tokenize_returns_expected_arrays():


### PR DESCRIPTION
## Summary
- `expected_token` in [tests/test_env.py](tests/test_env.py) was prepending a coefficient column to the monomial array, but `tokenize()` in [grobnerRl/env.py:18-34](grobnerRl/env.py:18) returns monomials only.
- Drop the coefficient column from the helper so it aligns with the current `tokenize()` contract.
- Fixes 4 pre-existing failures: `test_tokenize_returns_expected_arrays`, `test_tokenize_handles_negative_coefficients`, `test_make_obs_tokenizes_and_copies_pairs`, `test_buchberger_env_reset_train_mode_tokenizes_state`.

## Test plan
- [x] `~/.venv/bin/python -m pytest tests/test_env.py -k "tokenize or train_mode_tokenizes_state"` — 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)