### PR TITLE
Align GVWEnv reward scheme with BuchbergerEnv

### DIFF
--- a/grobnerRl/env.py
+++ b/grobnerRl/env.py
@@ -282,10 +282,16 @@ def _regular_top_reduce(
     div_fn: Callable,
     mul_fn: Callable,
     order_fn: Callable,
-) -> PolyElement:
-    """Perform regular top reduction on a polynomial."""
+) -> tuple[PolyElement, dict]:
+    """Perform regular top reduction on a polynomial.
+
+    Returns:
+        Tuple of (reduced polynomial, stats) where stats contains:
+        - 'steps': number of polynomial subtractions performed
+    """
+    stats = {"steps": 0}
     if not signatures:
-        return poly
+        return poly, stats
 
     while poly != 0:
         lm_poly, lc_poly = poly.LT
@@ -298,12 +304,13 @@ def _regular_top_reduce(
             if _signature_lt(sig_mult, signature, initial_lms, mul_fn, order_fn):
                 ratio = lc_poly / reducer.LC
                 poly = poly - reducer.mul_term((mult, ratio))
+                stats["steps"] += 1
                 reduced = True
                 break
         if not reduced:
             break
 
-    return poly
+    return poly, stats
 
 
 def _is_super_top_reducible(
@@ -447,13 +454,14 @@ def _process_pair(state: dict[str, Any], index: int) -> dict[str, Any]:
         "signature": signature,
         "poly_added": False,
         "syzygy_added": False,
+        "reduction_steps": 0,
     }
 
     if _is_blocked(signature, state["syzygies"], div_fn):
         return result
 
     working_poly = poly.copy()
-    working_poly = _regular_top_reduce(
+    working_poly, reduce_stats = _regular_top_reduce(
         signature,
         working_poly,
         state["signatures"],
@@ -463,6 +471,7 @@ def _process_pair(state: dict[str, Any], index: int) -> dict[str, Any]:
         mul_fn,
         order_fn,
     )
+    result["reduction_steps"] = reduce_stats["steps"]
 
     if working_poly == 0:
         state["syzygies"].add(signature)
@@ -853,10 +862,29 @@ class BuchbergerEnv(BaseEnv):
 class GVWEnv(BaseEnv):
     """Gymnasium environment wrapping the GVW signature-based Buchberger algorithm."""
 
-    def __init__(self, ideal_generator: IdealGenerator, mode="eval"):
+    def __init__(
+        self,
+        ideal_generator: IdealGenerator,
+        mode: str = "eval",
+        rewards: str = "additions",
+    ):
+        """
+        Initialize the GVW environment.
+
+        Parameters:
+        ideal_generator: IdealGenerator - Generator for ideals to be used in the environment.
+        mode: str - Mode of the environment ('train' or 'eval').
+        rewards: str - Reward scheme. 'additions' (default) returns -(1 + reduction steps)
+            per step. 'reductions' returns -1 per step regardless of reduction cost.
+            Both schemes return 0 on the terminal step.
+        """
+        if rewards not in ("additions", "reductions"):
+            raise ValueError("rewards must be 'additions' or 'reductions'")
+
         super().__init__(ideal_generator)
         self.ideal_generator = ideal_generator
         self.mode = mode
+        self.rewards = rewards
 
         self._state: dict[str, Any] = {}
         self.generators: list[PolyElement] = []
@@ -912,7 +940,7 @@ class GVWEnv(BaseEnv):
         return index
 
     def step(
-        self, action: int | tuple[int, int]
+        self, action: int | tuple[int, int] | tuple[tuple[int, ...], int]
     ) -> tuple[
         tuple[list[ArrayLike] | list[PolyElement], list[tuple[int, int]]],
         int,
@@ -924,7 +952,8 @@ class GVWEnv(BaseEnv):
         Take a step in the environment based on the given action.
 
         Parameters:
-        action: int | tuple[int, int] - The action to take (either an integer or a signature tuple).
+        action: int | tuple[tuple[int, ...], int] - The action to take, either an
+            integer index into the current pair list or an explicit signature tuple.
 
         Returns:
         - A tuple containing the new observation, reward, termination status, truncation status, and additional info.
@@ -933,14 +962,17 @@ class GVWEnv(BaseEnv):
             raise ValueError("no pairs available to process")
 
         index = self._resolve_action(action)
-        _process_pair(self._state, index)
+        result = _process_pair(self._state, index)
 
         # Update instance variables to reflect state changes
         self.generators = self._state["generators"]
         self.pairs = self._state["pairs"]
 
-        reward = -1
         terminated = not bool(self._state.get("jpairs"))
+        if self.rewards == "additions":
+            reward = -(1 + result.get("reduction_steps", 0)) if not terminated else 0
+        else:
+            reward = -1 if not terminated else 0
 
         return self._current_observation(), reward, terminated, False, {}
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1050,17 +1050,76 @@ def test_gvw_env_matches_gvw_buchberger_result():
     assert set(env_basis) == set(expected_basis)
 
 
-def test_gvw_env_reward_is_always_negative_one():
-    """Test that reward is always -1 for each step."""
-    env = GVWEnv(DummyIdealGenerator([[x**2 - y, x * y - 1]]), mode="eval")
+def test_gvw_env_invalid_rewards_raises():
+    """Test that invalid rewards argument raises ValueError."""
+    with pytest.raises(ValueError, match="rewards must be 'additions' or 'reductions'"):
+        GVWEnv(DummyIdealGenerator([[x + y]]), rewards="bogus")
+
+
+def test_gvw_env_default_rewards_is_additions():
+    """Test that the default reward scheme is 'additions'."""
+    env = GVWEnv(DummyIdealGenerator([[x + y]]))
+    assert env.rewards == "additions"
+
+
+def test_gvw_env_rewards_reductions_returns_negative_one():
+    """Test that 'reductions' mode returns -1 for every non-terminal step."""
+    env = GVWEnv(
+        DummyIdealGenerator([[x**2 - y, x * y - 1]]), mode="eval", rewards="reductions"
+    )
+    env.reset()
+
+    non_terminal_rewards = []
+    final_reward = None
+    while env.pairs:
+        _, reward, terminated, _, _ = env.step(0)
+        if terminated:
+            final_reward = reward
+        else:
+            non_terminal_rewards.append(reward)
+
+    assert non_terminal_rewards  # at least one non-terminal step occurred
+    assert all(r == -1 for r in non_terminal_rewards)
+    assert final_reward == 0
+
+
+def test_gvw_env_rewards_additions_returns_step_cost():
+    """Test that 'additions' mode returns -(1 + reduction_steps) per step."""
+    env = GVWEnv(
+        DummyIdealGenerator([[x**2 - y, x * y - 1]]), mode="eval", rewards="additions"
+    )
     env.reset()
 
     rewards = []
     while env.pairs:
-        _, reward, _, _, _ = env.step(0)
-        rewards.append(reward)
+        _, reward, terminated, _, _ = env.step(0)
+        if not terminated:
+            rewards.append(reward)
 
-    assert all(r == -1 for r in rewards)
+    assert rewards
+    assert all(r <= -1 for r in rewards)
+    # At least one step in this ideal should trigger a regular top reduction,
+    # producing reward strictly less than -1.
+    assert any(r < -1 for r in rewards)
+
+
+def test_gvw_env_terminal_reward_is_zero():
+    """Test that terminal step reward is 0 in both reward modes."""
+    for mode in ("additions", "reductions"):
+        env = GVWEnv(
+            DummyIdealGenerator([[x * y - 1, x - 1]]), mode="eval", rewards=mode
+        )
+        env.reset()
+
+        last_reward = None
+        last_terminated = False
+        while env.pairs:
+            _, reward, terminated, _, _ = env.step(0)
+            last_reward = reward
+            last_terminated = terminated
+
+        assert last_terminated
+        assert last_reward == 0
 
 
 def test_gvw_env_multiple_resets():


### PR DESCRIPTION
## Summary
- Add `rewards` parameter to `GVWEnv` (`"additions"` default, or `"reductions"`) with validation, matching `BuchbergerEnv`'s interface.
- Terminal step now yields reward `0` (was always `-1`).
- Instrument `_regular_top_reduce` to return reduction step counts so `"additions"` mode can compute `-(1 + steps)` per step.
- Widen `GVWEnv.step`'s action type hint to include signature tuples (`tuple[tuple[int, ...], int]`).

## Why
`GVWEnv` had drifted from `BuchbergerEnv`: hard-coded `reward = -1` every step including terminal, no `rewards` parameter, and a misleading type hint. The GVW algorithm itself was audited and confirmed faithful to standard Gao-Volny-Wang — only the env wrapper diverged.

## Test plan
- [x] `~/.venv/bin/python -m pytest tests/test_env.py -v -k gvw` — 49/49 pass
- [x] Full `tests/test_env.py` suite — only 4 pre-existing tokenize failures unrelated to this change
- [x] New tests cover: invalid `rewards` arg, default kwarg, both reward modes, terminal reward = 0
- [x] Existing tests that assert `reward == -1` after a single step still pass (first step has 0 reduction steps, so `-(1 + 0) == -1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)